### PR TITLE
Fix PostCSS config location

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/postcss.config.js
+++ b/src/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}


### PR DESCRIPTION
## Summary
- move PostCSS config from `src/` to the project root
- remove the empty root config file

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: cannot find ESLint package)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855c88ae42c832d9e6ec431ad57c927