### PR TITLE
Add serve script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,23 @@ export default tseslint.config({
     // other rules...
     // Enable its recommended typescript rules
     ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
+  ...reactDom.configs.recommended.rules,
   },
 })
 ```
+
+## Build and Serve
+
+Run the build command to create the production output:
+
+```bash
+npm run build
+```
+
+Afterwards you can preview the built site locally:
+
+```bash
+npm run serve
+```
+
+This serves the `dist` directory on port `4173`.

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "preview": "vite preview"
-  },
+    "scripts": {
+      "dev": "vite",
+      "build": "tsc -b && vite build",
+      "lint": "eslint .",
+      "preview": "vite preview",
+      "serve": "npx serve -s dist -l 4173"
+    },
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 // src/App.tsx
 
-import React from 'react';
 import Home from './pages/Home';
 
 function App() {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Summary
- add a `serve` script for serving the built site
- document how to build and serve
- remove unused React imports so TypeScript build passes lint

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6855c88cf960832da3f6164510185121