### PR TITLE
Update README with production serve steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,16 @@ export default tseslint.config({
   },
 })
 ```
+
+## Running locally
+
+Use the following steps to build the project and serve the production bundle:
+
+```bash
+cd land_plf
+npm install
+npm run build
+npx serve -s dist -l 4173
+```
+
+`npx serve` is required because Vite's dev server is not supported in Codex.


### PR DESCRIPTION
## Summary
- document how to run the project locally

## Testing
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6855c87fe4ec832da472b523df75204b