### PR TITLE
Automate GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,51 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          VITE_BASE_URL: /land_plf/
+
+      - name: Verify referral assets
+        run: |
+          test -f dist/referral/index.html
+          test -f dist/referral/app.js
+          test -f dist/referral/styles.css
+          test -f dist/referral/privacy.html
+          test -f dist/referral/terms.html
+
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          force_orphan: false


### PR DESCRIPTION
## What changed

- added a GitHub Actions workflow that builds the Vite app on every push to `main`
- verifies the Referral Growth Engine static assets exist in `dist/referral/`
- publishes the complete `dist` directory to the existing `gh-pages` branch

## Why

The repository had a manual `npm run deploy` command and an existing `gh-pages` branch, but no automatic deployment workflow. Without this change, the merged Referral Growth Engine would not be published automatically.

## Validation

The workflow uses Node 20, `npm ci`, the existing `npm run build` script and the repository's `/land_plf/` Vite base path. Deployment uses the repository-scoped `GITHUB_TOKEN` with contents write permission.